### PR TITLE
Chapter 9 Exercises

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/error_messages' %>
+<%= render 'shared/error_messages', object: f.object %>
 
 <%= f.label :name %>
 <%= f.text_field :name, class: 'form-control' %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,13 @@
+<%= render 'shared/error_messages' %>
+
+<%= f.label :name %>
+<%= f.text_field :name, class: 'form-control' %>
+
+<%= f.label :email %>
+<%= f.email_field :email, class: 'form-control' %>
+
+<%= f.label :password %>
+<%= f.password_field :password, class: 'form-control' %>
+
+<%= f.label :password_confirmation, "Confirmation" %>
+<%= f.password_field :password_confirmation, class: 'form-control' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,20 +4,7 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
+      <%= render partial: "form", locals: {f: f} %>
       <%= f.submit "Save changes", class: "btn btn-primary" %>
     <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,20 +4,7 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
+      <%= render partial: "form", locals: {f: f} %>
       <%= f.submit "Create my account", class: "btn btn-primary" %>
     <% end %>
   </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -48,7 +48,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_not @other_user.admin?
     patch :update, id: @other_user, user: { password:              "",
                                             password_confirmation: "",
-                                            admin: 1}
+                                            admin: "1"}
     assert_not @other_user.reload.admin?
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -43,6 +43,15 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
+  test "should not allow the admin attribute to be edited via the web" do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+    patch :update, id: @other_user, user: { password:              "",
+                                            password_confirmation: "",
+                                            admin: 1}
+    assert_not @other_user.reload.admin?
+  end
+
   test "should redirect destroy when not logged in" do
     assert_no_difference 'User.count' do
       delete :destroy, id: @user

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -2,12 +2,41 @@ require 'test_helper'
 
 class SiteLayoutTest < ActionDispatch::IntegrationTest
 
-  test "layout links" do
+  def setup
+    @user = users(:michael)
+  end
+
+
+  test "layout links (non-logged-in)" do
     get root_path
     assert_template 'static_pages/home'
     assert_select "a[href=?]", root_path, count: 2
     assert_select "a[href=?]", help_path
     assert_select "a[href=?]", about_path
     assert_select "a[href=?]", contact_path
+    assert_select "a[href=?]", signup_path
+    assert_select "a[href=?]", login_path
+    assert_select "a[href=?]", new_user_path, count: 0
+    assert_select "a[href=?]", user_path(@user), count: 0
+    assert_select "a[href=?]", users_path, count: 0
+    assert_select "a[href=?]", edit_user_path(@user), count: 0
+    assert_select "a[href=?]", logout_path, count: 0
+  end
+
+  test "layout links (logged-in)" do
+    log_in_as(@user)
+    get root_path
+    assert_template 'static_pages/home'
+    assert_select "a[href=?]", root_path, count: 2
+    assert_select "a[href=?]", help_path
+    assert_select "a[href=?]", about_path
+    assert_select "a[href=?]", contact_path
+    assert_select "a[href=?]", signup_path
+    assert_select "a[href=?]", login_path, count: 0
+    assert_select "a[href=?]", new_user_path, count: 0
+    assert_select "a[href=?]", user_path(@user)
+    assert_select "a[href=?]", users_path
+    assert_select "a[href=?]", edit_user_path(@user)
+    assert_select "a[href=?]", logout_path
   end
 end

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -31,7 +31,7 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", help_path
     assert_select "a[href=?]", about_path
     assert_select "a[href=?]", contact_path
-    assert_select "a[href=?]", signup_path
+    # assert_select "a[href=?]", signup_path
     assert_select "a[href=?]", login_path, count: 0
     assert_select "a[href=?]", new_user_path, count: 0
     assert_select "a[href=?]", user_path(@user)

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -21,6 +21,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     get edit_user_path(@user)
     log_in_as(@user)
     assert_redirected_to edit_user_path(@user)
+    assert_nil session[:forwarding_url]
     name  = "Foo Bar"
     email = "foo@bar.com"
     patch user_path(@user), user: { name:  name,


### PR DESCRIPTION
https://www.railstutorial.org/book/updating_and_deleting_users

# 問題内容

1. Write a test to make sure that friendly forwarding only forwards to the given URL the first time. On subsequent login attempts, the forwarding URL should revert to the default (i.e., the profile page). Hint: Add to the test in Listing 9.26 by checking for the right value of session[:forwarding_url].
2. Write an integration test for all the layout links, including the proper behavior for logged-in and non-logged-in users. Hint: Add to the test in Listing 5.25 using the log_in_as helper.
3. By issuing a PATCH request directly to the update method as shown in Listing 9.59, verify that the admin attribute isn’t editable through the web. To be sure your test is covering the right thing, your first step should be to add admin to the list of permitted parameters in user_params so that the initial test is red.
4. Remove the duplicated form code by refactoring the new.html.erb and edit.html.erb views to use the partial in Listing 9.60. Note that you will have to pass the form variable f explicitly as a local variable, as shown in Listing 9.61.

# ToDo

- [x]  friendly forwarding後 (非ログイン時にログインが必要なページにアクセスし，loginを求められ，ログインが必要なページにredirectされたあとで) session[:forwarding_url]が空になっていること
- [x] rootに必要なリンクが全て揃っており，表示すべきではないものがきちんと表示されていないこと (ログイン時/非ログイン時両方)
- [x] paramsにadminについてのパラメータが書かれていても，それを無視して更新しないこと
- [x] user/new.html.erbとuser/edit.html.erbのフォーム内容がほとんど同じなため，部分テンプレート化して使いまわすこと

# Close条件

- [x] テストがオールグリーン
- [x] 最低2人のOKをもらう

