### PR TITLE
gemのrails_12factorを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :test do
 end
 
 group :production do
-  gem 'rails_12factor', '0.0.2'
+  # gem 'rails_12factor', '0.0.2'
   # gem 'puma',           '2.11.1'
   # gem 'fog'
   # gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,11 +170,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
-    rails_12factor (0.0.2)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.4)
-    rails_stdout_logging (0.0.3)
     railties (4.2.3)
       actionpack (= 4.2.3)
       activesupport (= 4.2.3)
@@ -271,7 +266,6 @@ DEPENDENCIES
   minitest-reporters (= 1.0.5)
   mysql2 (= 0.3.18)
   rails (= 4.2.3)
-  rails_12factor (= 0.0.2)
   sass-rails (= 5.0.2)
   sdoc (= 0.4.0)
   spring (= 1.1.3)


### PR DESCRIPTION
なぜ消して欲しいのか: rails_12factor内で `config.serve_static_assets` がtrueになっているので、静的ファイルを別サーバへ分離できないからです。